### PR TITLE
Image processing

### DIFF
--- a/Controllers/FarewellPersonController.cs
+++ b/Controllers/FarewellPersonController.cs
@@ -37,6 +37,7 @@ public class FarewellPersonController : Controller
                 Name = viewModel.Name,
                 Description = viewModel.Description,
                 Slug = GenerateSlug(viewModel.Name),
+                Email = viewModel.Email,
                 IsPublic = true,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow

--- a/FarewellMyBeloved.csproj
+++ b/FarewellMyBeloved.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
   </ItemGroup>
 
 </Project>

--- a/FarewellMyBeloved.csproj
+++ b/FarewellMyBeloved.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="4.0.6.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Migrations/20250828061552_AddEmailToFarewellPerson.Designer.cs
+++ b/Migrations/20250828061552_AddEmailToFarewellPerson.Designer.cs
@@ -4,6 +4,7 @@ using FarewellMyBeloved.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FarewellMyBeloved.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250828061552_AddEmailToFarewellPerson")]
+    partial class AddEmailToFarewellPerson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250828061552_AddEmailToFarewellPerson.cs
+++ b/Migrations/20250828061552_AddEmailToFarewellPerson.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FarewellMyBeloved.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailToFarewellPerson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Email",
+                table: "FarewellPeople",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Email",
+                table: "FarewellPeople");
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -40,6 +40,10 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.BackgroundUrl)
                 .HasMaxLength(500);
             
+            entity.Property(e => e.Email)
+                .HasMaxLength(255)
+                .HasAnnotation("EmailAddress", true);
+            
             entity.Property(e => e.IsPublic)
                 .IsRequired();
             

--- a/Models/FarewellPerson.cs
+++ b/Models/FarewellPerson.cs
@@ -26,6 +26,10 @@ public class FarewellPerson
 
     public string? BackgroundUrl { get; set; }
 
+    [EmailAddress(ErrorMessage = "Invalid email address")]
+    [StringLength(255, ErrorMessage = "Email cannot exceed 255 characters")]
+    public string? Email { get; set; }
+
     [Required]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/Models/FarewellPerson.cs
+++ b/Models/FarewellPerson.cs
@@ -22,10 +22,8 @@ public class FarewellPerson
     [StringLength(5000, ErrorMessage = "Description cannot exceed 5000 characters")]
     public string Description { get; set; } = string.Empty;
 
-    [StringLength(500, ErrorMessage = "Portrait URL cannot exceed 500 characters")]
     public string? PortraitUrl { get; set; }
 
-    [StringLength(500, ErrorMessage = "Background URL cannot exceed 500 characters")]
     public string? BackgroundUrl { get; set; }
 
     [Required]

--- a/Program.cs
+++ b/Program.cs
@@ -1,9 +1,29 @@
+using Amazon.S3;
 using Microsoft.EntityFrameworkCore;
+using FarewellMyBeloved.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
+
+// Add S3 Service
+var awsConfig = builder.Configuration.GetSection("S3");
+var accessKeyId = awsConfig["AccessKey"];
+var secretAccessKey = awsConfig["SecretKey"];
+var endpoint = awsConfig["Endpoint"]; // e.g., "s3.us-west-002.backblazeb2.com"
+
+// Create a custom endpoint for Backblaze B2
+var config = new AmazonS3Config
+{
+    ServiceURL = endpoint,
+    ForcePathStyle = true // Required for Backblaze B2
+};
+
+// Initialize the S3 client with Backblaze B2 credentials
+var s3Client = new AmazonS3Client(accessKeyId, secretAccessKey, config);
+builder.Services.AddSingleton<IAmazonS3>(s3Client);
+builder.Services.AddScoped<IS3Service, S3Service>();
 
 // Add Entity Framework services
 builder.Services.AddDbContext<FarewellMyBeloved.Models.ApplicationDbContext>(options =>

--- a/Services/IS3Service.cs
+++ b/Services/IS3Service.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace FarewellMyBeloved.Services
+{
+    public interface IS3Service
+    {
+        Task<string> UploadFileAsync(IFormFile file);
+        Task<string> GetSignedUrlAsync(string key);
+    }
+}

--- a/Services/S3Service.cs
+++ b/Services/S3Service.cs
@@ -1,0 +1,94 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace FarewellMyBeloved.Services
+{
+    public class S3Service : IS3Service
+    {
+        private readonly IAmazonS3 _s3Client;
+        private readonly IConfiguration _configuration;
+
+        public S3Service(IAmazonS3 s3Client, IConfiguration configuration)
+        {
+            _s3Client = s3Client;
+            _configuration = configuration;
+        }
+
+        public async Task<string> UploadFileAsync(IFormFile file)
+        {
+            // Validate input
+            if (file == null || file.Length == 0)
+            {
+                throw new ArgumentException("No file uploaded or file is empty.");
+            }
+
+            // Retrieve configuration
+            var bucketName = _configuration.GetSection("S3")["Bucket"];
+            var endpoint = _configuration.GetSection("S3")["Endpoint"];
+            
+            if (string.IsNullOrEmpty(bucketName) || string.IsNullOrEmpty(endpoint))
+            {
+                throw new InvalidOperationException("S3 bucket or endpoint configuration is missing.");
+            }
+
+            // Generate unique key for the file
+            var key = $"{Guid.NewGuid()}-{Path.GetFileName(file.FileName)}";
+
+            // Buffer file into MemoryStream for validation
+            using (var stream = new MemoryStream())
+            {
+                // Copy file to MemoryStream
+                await file.CopyToAsync(stream);
+
+                // Validate stream length
+                if (stream.Length != file.Length)
+                {
+                    throw new InvalidOperationException("File was not copied correctly to stream.");
+                }
+
+                // Reset stream position
+                stream.Position = 0;
+
+                // Prepare S3 upload request
+                var request = new PutObjectRequest
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    InputStream = stream,
+                    ContentType = file.ContentType ?? "application/octet-stream",
+                    CannedACL = S3CannedACL.PublicRead,
+                    DisablePayloadSigning = true, // Disable chunked encoding signatures
+                    DisableDefaultChecksumValidation = true // Explicitly disable checksums
+                };
+
+                // Explicitly disable checksum algorithm
+                request.ChecksumAlgorithm = null;
+
+                // Upload to S3
+                await _s3Client.PutObjectAsync(request);
+
+                // Construct and return the file URL
+                var url = $"{endpoint.TrimEnd('/')}/{bucketName}/{key}";
+                return url;
+            }
+        }
+
+        public async Task<string> GetSignedUrlAsync(string key)
+        {
+            var bucketName = _configuration.GetSection("S3")["Bucket"];
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                Expires = DateTime.UtcNow.AddHours(1) // 60 minutes expiration
+            };
+
+            return await _s3Client.GetPreSignedURLAsync(request);
+        }
+    }
+}

--- a/ViewModels/CreateFarewellPersonViewModel.cs
+++ b/ViewModels/CreateFarewellPersonViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
 
 namespace FarewellMyBeloved.ViewModels;
 
@@ -12,9 +13,17 @@ public class CreateFarewellPersonViewModel
     [StringLength(5000, ErrorMessage = "Description cannot exceed 5000 characters")]
     public string Description { get; set; } = string.Empty;
 
+    public bool UsePortraitUrl { get; set; }
+
     [StringLength(500, ErrorMessage = "Portrait URL cannot exceed 500 characters")]
     public string? PortraitUrl { get; set; }
 
+    public IFormFile? PortraitFile { get; set; }
+
+    public bool UseBackgroundUrl { get; set; }
+
     [StringLength(500, ErrorMessage = "Background URL cannot exceed 500 characters")]
     public string? BackgroundUrl { get; set; }
+
+    public IFormFile? BackgroundFile { get; set; }
 }

--- a/ViewModels/CreateFarewellPersonViewModel.cs
+++ b/ViewModels/CreateFarewellPersonViewModel.cs
@@ -26,4 +26,8 @@ public class CreateFarewellPersonViewModel
     public string? BackgroundUrl { get; set; }
 
     public IFormFile? BackgroundFile { get; set; }
+
+    [EmailAddress(ErrorMessage = "Invalid email address")]
+    [StringLength(255, ErrorMessage = "Email cannot exceed 255 characters")]
+    public string? Email { get; set; }
 }

--- a/Views/FarewellMessage/Create.cshtml
+++ b/Views/FarewellMessage/Create.cshtml
@@ -70,7 +70,7 @@
                                 <span asp-validation-for="AuthorEmail" class="text-danger small"></span>
                                 <small class="form-text text-muted">
                                     <i class="fas fa-info-circle me-1"></i>
-                                    Optional - Your email will not be displayed publicly
+                                    Optional - We'll reach out if we need to moderate your Message.
                                 </small>
                             </div>
                         </div>

--- a/Views/FarewellPerson/Create.cshtml
+++ b/Views/FarewellPerson/Create.cshtml
@@ -66,8 +66,9 @@
                                 <span asp-validation-for="PortraitUrl" class="text-danger small"></span>
                             </div>
                             <div id="portraitFileInput" style="display: none;">
-                                <input asp-for="PortraitFile" class="form-control" type="file" />
+                                <input asp-for="PortraitFile" class="form-control" type="file" accept="image/*" onchange="validateImageSize(this, 'PortraitFile')" />
                                 <span asp-validation-for="PortraitFile" class="text-danger small"></span>
+                                <span id="portraitFileSizeError" class="text-danger small" style="display: none;"></span>
                             </div>
                         </div>
                         
@@ -92,8 +93,9 @@
                                 <span asp-validation-for="BackgroundUrl" class="text-danger small"></span>
                             </div>
                             <div id="backgroundFileInput" style="display: none;">
-                                <input asp-for="BackgroundFile" class="form-control" type="file" />
+                                <input asp-for="BackgroundFile" class="form-control" type="file" accept="image/*" onchange="validateImageSize(this, 'BackgroundFile')" />
                                 <span asp-validation-for="BackgroundFile" class="text-danger small"></span>
+                                <span id="backgroundFileSizeError" class="text-danger small" style="display: none;"></span>
                             </div>
                         </div>
                         
@@ -138,5 +140,20 @@
                 }
             });
         });
+
+        function validateImageSize(input, fieldName) {
+            const maxSize = 5 * 1024 * 1024; // 5MB
+            const fileSizeError = document.getElementById(fieldName + 'FileSizeError');
+            
+            if (input.files && input.files[0]) {
+                if (input.files[0].size > maxSize) {
+                    fileSizeError.textContent = 'File size must be less than 5MB.';
+                    fileSizeError.style.display = 'block';
+                    input.value = ''; // Clear the file input
+                } else {
+                    fileSizeError.style.display = 'none';
+                }
+            }
+        }
     </script>
 }

--- a/Views/FarewellPerson/Create.cshtml
+++ b/Views/FarewellPerson/Create.cshtml
@@ -15,7 +15,7 @@
                     </h2>
                 </div>
                 <div class="card-body p-4">
-                    <form asp-action="Create">
+                    <form asp-action="Create" enctype="multipart/form-data">
                         <div asp-validation-summary="ModelOnly" class="text-danger alert alert-danger"></div>
                         
                         <div class="mb-4">
@@ -35,27 +35,55 @@
                         </div>
                         
                         <div class="mb-4">
-                            <label asp-for="PortraitUrl" class="form-label fw-bold">
-                                <i class="fas fa-image me-2"></i>Portrait URL
+                            <label class="form-label fw-bold">
+                                <i class="fas fa-image me-2"></i>Portrait
                             </label>
-                            <input asp-for="PortraitUrl" class="form-control" placeholder="https://example.com/portrait.jpg" />
-                            <span asp-validation-for="PortraitUrl" class="text-danger small"></span>
-                            <small class="form-text text-muted">
-                                <i class="fas fa-info-circle me-1"></i>
-                                Optional URL to a portrait image
-                            </small>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="UsePortraitUrl" id="portraitUrlRadio" value=true checked>
+                                <label class="form-check-label" for="portraitUrlRadio">
+                                    Use URL
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="UsePortraitUrl" id="portraitFileRadio" value=false>
+                                <label class="form-check-label" for="portraitFileRadio">
+                                    Upload File
+                                </label>
+                            </div>
+                            <div id="portraitUrlInput">
+                                <input asp-for="PortraitUrl" class="form-control" placeholder="https://example.com/portrait.jpg" />
+                                <span asp-validation-for="PortraitUrl" class="text-danger small"></span>
+                            </div>
+                            <div id="portraitFileInput" style="display: none;">
+                                <input asp-for="PortraitFile" class="form-control" type="file" />
+                                <span asp-validation-for="PortraitFile" class="text-danger small"></span>
+                            </div>
                         </div>
                         
                         <div class="mb-5">
-                            <label asp-for="BackgroundUrl" class="form-label fw-bold">
-                                <i class="fas fa-photo-video me-2"></i>Background URL
+                            <label class="form-label fw-bold">
+                                <i class="fas fa-photo-video me-2"></i>Background
                             </label>
-                            <input asp-for="BackgroundUrl" class="form-control" placeholder="https://example.com/background.jpg" />
-                            <span asp-validation-for="BackgroundUrl" class="text-danger small"></span>
-                            <small class="form-text text-muted">
-                                <i class="fas fa-info-circle me-1"></i>
-                                Optional URL to a background image
-                            </small>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="UseBackgroundUrl" id="backgroundUrlRadio" value=true checked>
+                                <label class="form-check-label" for="backgroundUrlRadio">
+                                    Use URL
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="UseBackgroundUrl" id="backgroundFileRadio" value=false>
+                                <label class="form-check-label" for="backgroundFileRadio">
+                                    Upload File
+                                </label>
+                            </div>
+                            <div id="backgroundUrlInput">
+                                <input asp-for="BackgroundUrl" class="form-control" placeholder="https://example.com/background.jpg" />
+                                <span asp-validation-for="BackgroundUrl" class="text-danger small"></span>
+                            </div>
+                            <div id="backgroundFileInput" style="display: none;">
+                                <input asp-for="BackgroundFile" class="form-control" type="file" />
+                                <span asp-validation-for="BackgroundFile" class="text-danger small"></span>
+                            </div>
                         </div>
                         
                         <div class="d-grid gap-2 d-md-flex justify-content-md-center">
@@ -75,4 +103,29 @@
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+    <script>
+        $(document).ready(function () {
+            $('input[type=radio][name=UsePortraitUrl]').change(function() {
+                if (this.value == 'true') {
+                    $('#portraitUrlInput').show();
+                    $('#portraitFileInput').hide();
+                }
+                else if (this.value == 'false') {
+                    $('#portraitUrlInput').hide();
+                    $('#portraitFileInput').show();
+                }
+            });
+
+            $('input[type=radio][name=UseBackgroundUrl]').change(function() {
+                if (this.value == 'true') {
+                    $('#backgroundUrlInput').show();
+                    $('#backgroundFileInput').hide();
+                }
+                else if (this.value == 'false') {
+                    $('#backgroundUrlInput').hide();
+                    $('#backgroundFileInput').show();
+                }
+            });
+        });
+    </script>
 }

--- a/Views/FarewellPerson/Create.cshtml
+++ b/Views/FarewellPerson/Create.cshtml
@@ -33,6 +33,17 @@
                             <textarea asp-for="Description" class="form-control" rows="5" placeholder="Enter a description about this person..."></textarea>
                             <span asp-validation-for="Description" class="text-danger small"></span>
                         </div>
+
+                        <div class="mb-4">
+                            <label asp-for="Email" class="form-label fw-bold">
+                                <i class="fas fa-envelope me-2"></i>Your Email
+                            </label>
+                            <input asp-for="Email" class="form-control" placeholder="Enter email address (Optional)" />
+                            <span asp-validation-for="Email" class="text-danger small"></span>
+                            <div class="form-text text-muted">
+                                We'll reach out if we need to moderate your page.
+                            </div>
+                        </div>
                         
                         <div class="mb-4">
                             <label class="form-label fw-bold">

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,5 +8,11 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=FarewellMyBeloved;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "S3": {
+    "Bucket": "farewell-my-beloved-images",
+    "AccessKey": "YOUR_S3_ACCESS_KEY",
+    "SecretKey": "YOUR_S3_SECRET_KEY",
+    "Endpoint": "https://s3.filebase.com"
   }
 }


### PR DESCRIPTION
# Added S3 Image Upload, File Size Limit, and Email Field for Moderation
 - Enhanced the platform’s media and moderation features:
 - Integrated Amazon S3 for image uploads (replacing reliance on imgBB).
 - Added file size limit validation for uploaded images to ensure performance and prevent abuse.
 - Introduced an Email field in FarewellPerson for moderation and administrative follow-up.

## References
 - Section 5 (File Upload Specification) and Section 7 (Security Considerations) of SOFTWARE_SPECIFICATION.md

## Setup
 - Configure AWS S3 credentials in appsettings.json.
 - Run EF Core migration to apply the new Email column in FarewellPerson.

## Notes
 - Flushing the database is recommended to ensure schema consistency.
 - imgBB integration can be deprecated in future cleanup.

## Next step:
 - Add admin/moderation panel functionality to make use of the stored email field.